### PR TITLE
Revert to dynamic linking on OS X.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+age_align
+obj/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 VERSION = v0.4
-DEFAULT_FLAGS = -DAGE_VERSION=\"$(VERSION)\" -DAGE_TIME -static -O3
+UNAME_S := $(shell uname -s)
+ifneq ($(UNAME_S),Darwin)
+	STAT_LINK = -static
+else
+	STAT_LINK = ""
+endif
+DEFAULT_FLAGS = -DAGE_VERSION=\"$(VERSION)\" -DAGE_TIME $(STAT_LINK) -O3
+
 CXX	= g++ -fopenmp -DOMP $(DEFAULT_FLAGS)
 
 MESS = "Compiling with parallel support."
@@ -29,7 +36,7 @@ mess:
 	@echo ""
 
 age_align: $(OBJS)
-	$(CXX) -o $@ $(OBJS) -static
+	$(CXX) -o $@ $(OBJS) $(STAT_LINK)
 
 $(OBJDIR)/%.o: %.cpp
 	@mkdir -p $(OBJDIR)


### PR DESCRIPTION
I wasn't able to build the `simple-parseable-output` branch on Mac OS X Yosemite, see http://stackoverflow.com/questions/5259249/creating-static-mac-os-x-c-build/5259427#5259427. I made the `-static` flag in the Makefile conditional on not being run on Darwin.
